### PR TITLE
Oxwich50 keyboard, and initial richdawe keymap

### DIFF
--- a/keyboards/oxwich50/config.h
+++ b/keyboards/oxwich50/config.h
@@ -1,0 +1,20 @@
+// Copyright 2024 Elliot Powell (@Elliot Powell)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT

--- a/keyboards/oxwich50/info.json
+++ b/keyboards/oxwich50/info.json
@@ -1,0 +1,97 @@
+{
+    "manufacturer": "Elliot Powell",
+    "keyboard_name": "oxwich50",
+    "maintainer": "Elliot Powell",
+    "bootloader": "rp2040",
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true
+    },
+    "matrix_pins": {
+        "cols": [
+            "GP23",
+            "GP24",
+            "GP25",
+            "GP26",
+            "GP27",
+            "GP28",
+            "GP2",
+            "GP11",
+            "GP3",
+            "GP10",
+            "GP4",
+            "GP5",
+            "GP6"
+        ],
+        "rows": ["GP12", "GP13", "GP14", "GP15"]
+    },
+    "processor": "RP2040",
+    "url": "",
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x0000",
+        "vid": "0xFEED"
+    },
+    "layouts": {
+            "LAYOUT": {
+                "layout": [
+                    { "matrix": [0,0], "label": "Tab", "x": 0, "y": 0 },
+                    { "matrix": [0,1], "label": "Q", "x": 1, "y": 0 },
+                    { "matrix": [0,2], "label": "W", "x": 2, "y": 0 },
+                    { "matrix": [0,3], "label": "E", "x": 3, "y": 0 },
+                    { "matrix": [0,4], "label": "R", "x": 4, "y": 0 },
+                    { "matrix": [0,5], "label": "T", "x": 5, "y": 0 },
+                    { "matrix": [3,4], "label": "{", "x": 6, "y": 0 },
+                    { "matrix": [0,6], "label": "}", "x": 7.25, "y": 0 },
+                    { "matrix": [0,7], "label": "Y", "x": 8.25, "y": 0 },
+                    { "matrix": [0,8], "label": "U", "x": 9.25, "y": 0 },
+                    { "matrix": [0,9], "label": "I", "x": 10.25, "y": 0 },
+                    { "matrix": [0,10], "label": "O", "x": 11.25, "y": 0 },
+                    { "matrix": [0,11], "label": "P", "x": 12.25, "y": 0 },
+                    { "matrix": [0,12], "label": "Backspc", "x": 13.25, "y": 0, "w": 1.55 },
+                    { "matrix": [1,0], "label": "Esc", "x": 0.25, "y": 1 },
+                    { "matrix": [1,1], "label": "A", "x": 1.25, "y": 1 },
+                    { "matrix": [1,2], "label": "S", "x": 2.25, "y": 1 },
+                    { "matrix": [1,3], "label": "D", "x": 3.25, "y": 1 },
+                    { "matrix": [1,4], "label": "F", "x": 4.25, "y": 1 },
+                    { "matrix": [1,5], "label": "G", "x": 5.25, "y": 1 },
+                    { "matrix": [3,5], "label": "~", "x": 6.25, "y": 1 },
+                    { "matrix": [1,6], "label": "_", "x": 7.5, "y": 1 },
+                    { "matrix": [1,7], "label": "H", "x": 8.5, "y": 1 },
+                    { "matrix": [1,8], "label": "J", "x": 9.5, "y": 1 },
+                    { "matrix": [1,9], "label": "K", "x": 10.5, "y": 1 },
+                    { "matrix": [1,10], "label": "L", "x": 11.5, "y": 1 },
+                    { "matrix": [1,11], "label": ":", "x": 12.5, "y": 1 },
+                    { "matrix": [1,12], "label": "\"", "x": 13.5, "y": 1 },
+                    { "matrix": [2,0], "label": "Shift", "x": 0, "y": 2, "w": 1.75 },
+                    { "matrix": [2,1], "label": "Z", "x": 1.75, "y": 2 },
+                    { "matrix": [2,2], "label": "X", "x": 2.75, "y": 2 },
+                    { "matrix": [2,3], "label": "C", "x": 3.75, "y": 2 },
+                    { "matrix": [2,4], "label": "V", "x": 4.75, "y": 2 },
+                    { "matrix": [2,5], "label": "B", "x": 5.75, "y": 2 },
+                    { "matrix": [2,6], "label": "?", "x": 8, "y": 2 },
+                    { "matrix": [2,7], "label": "N", "x": 9, "y": 2 },
+                    { "matrix": [2,8], "label": "M", "x": 10, "y": 2 },
+                    { "matrix": [2,9], "label": "<", "x": 11, "y": 2 },
+                    { "matrix": [2,10], "label": ">", "x": 12, "y": 2 },
+                    { "matrix": [2,11], "label": "Up", "x": 13, "y": 2 },
+                    { "matrix": [2,12], "label": "Shift", "x": 14, "y": 2 },
+                    { "matrix": [3,0], "label": "Ctrl", "x": 0, "y": 3, "w": 1.25 },
+                    { "matrix": [3,1], "label": "Win", "x": 1.25, "y": 3, "w": 1.25 },
+                    { "matrix": [3,2], "label": "Alt", "x": 2.5, "y": 3, "w": 1.25 },
+                    { "matrix": [3,3], "label": "", "x": 3.75, "y": 3, "w": 2.75 },
+                    { "matrix": [3,7], "label": "", "x": 8.25, "y": 3, "w": 2.25 },
+                    { "matrix": [3,9], "label": "Alt", "x": 10.5, "y": 3, "w": 1.5 },
+                    { "matrix": [3,10], "label": "Left", "x": 12, "y": 3 },
+                    { "matrix": [3,11], "label": "Down", "x": 13, "y": 3 },
+                    { "matrix": [3,12], "label": "Right", "x": 14, "y": 3 }
+                ]
+            }
+
+    }
+}

--- a/keyboards/oxwich50/keymaps/default/keymap.c
+++ b/keyboards/oxwich50/keymaps/default/keymap.c
@@ -1,0 +1,24 @@
+// Copyright 2023 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┬───┐
+     * │ 7 │ 8 │ 9 │ / │
+     * ├───┼───┼───┼───┤
+     * │ 4 │ 5 │ 6 │ * │
+     * ├───┼───┼───┼───┤
+     * │ 1 │ 2 │ 3 │ - │
+     * ├───┼───┼───┼───┤
+     * │ 0 │ . │Ent│ + │
+     * └───┴───┴───┴───┘
+     */
+    [0] = LAYOUT(
+        KC_TAB,  KC_Q,    KC_W,    KC_E,     KC_R,    KC_T,    KC_LBRC, KC_RBRC,  KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_BSPC,
+        KC_ESC,  KC_A,    KC_S,    KC_D,     KC_F,    KC_G,    KC_GRV,  KC_MINS,  KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_SLSH,  KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   KC_ENT,
+        KC_LCTL, KC_LGUI, KC_LALT,           KC_SPC,                              KC_SPC,            KC_RCTL, KC_LEFT, KC_DOWN, KC_RIGHT
+    )
+};

--- a/keyboards/oxwich50/keymaps/richdawe/keymap.c
+++ b/keyboards/oxwich50/keymaps/richdawe/keymap.c
@@ -5,6 +5,7 @@
 
 #define LT1_SPC LT(1, KC_SPC)
 #define LT2_ESC LT(2, KC_ESC)
+#define LT3_TAB LT(3, KC_TAB)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Base layer
@@ -19,27 +20,36 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * └───┴───┴───┴───┘
      */
     [0] = LAYOUT(
-        KC_TAB,  KC_Q,    KC_W,    KC_E,     KC_R,    KC_T,    KC_LBRC, KC_RBRC,  KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_BSPC,
-        LT2_ESC, KC_A,    KC_S,    KC_D,     KC_F,    KC_G,    KC_GRV,  KC_MINS,  KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT,
-        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_B,     KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   KC_ENT,
-        KC_LCTL, KC_LGUI, KC_LALT,           LT1_SPC,                             LT1_SPC,           KC_SLSH, KC_LEFT, KC_DOWN, KC_RIGHT
+        LT3_TAB, KC_Q,    KC_W,    KC_E,     KC_R,    KC_T,    KC_LBRC, KC_RBRC,  KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_BSPC,
+        LT2_ESC, KC_A,    KC_S,    KC_D,     KC_F,    KC_G,    KC_TILD, KC_MINS,  KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_SLSH,  KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   KC_ENT,
+        KC_LCTL, KC_LGUI, KC_LALT,           LT1_SPC,                             LT1_SPC,           KC_LALT, KC_LEFT, KC_DOWN, KC_RIGHT
     ),
 
     /* Numbers and symbols layer
      */
     [1] = LAYOUT(
         KC_COLN, KC_1,    KC_2,    KC_3,     KC_4,    KC_5,    KC_LBRC, KC_RBRC,  KC_6,    KC_7,     KC_8,    KC_9,    KC_0,    KC_BSPC,
-        KC_DOT,  S(KC_1), S(KC_2), S(KC_3),  S(KC_4), S(KC_5), KC_GRV,  KC_MINS,  S(KC_6), S(KC_7),  S(KC_8), S(KC_9), S(KC_0), KC_BSLS,
-        _______, XXXXXXX, KC_GRV,  KC_TILD,  KC_PIPE, KC_PLUS,          KC_PLUS,  KC_MINS, KC_EQL,   KC_LBRC, KC_RBRC, KC_PGUP, _______,
-        _______, _______, _______,           _______,                             _______,           XXXXXXX, KC_HOME, KC_PGDN, KC_END
+        KC_DOT,  S(KC_1), S(KC_2), S(KC_3),  S(KC_4), S(KC_5), _______, _______,  S(KC_6), S(KC_7),  S(KC_8), S(KC_9), S(KC_0), KC_BSLS,
+        _______, XXXXXXX, KC_GRV,  KC_TILD,  KC_PIPE, KC_PLUS,          _______,  KC_MINS, KC_EQL,   KC_LBRC, KC_RBRC, KC_PGUP, _______,
+        _______, _______, _______,           _______,                             _______,           _______, KC_HOME, KC_PGDN, KC_END
     ),
 
     /* F-keys and media
      */
     [2] = LAYOUT(
-        KC_F12,  KC_F1,   KC_F2,   KC_F3,    KC_F4,   KC_F5,   KC_LBRC, KC_RBRC,  KC_F6,   KC_F7,    KC_F8,   KC_F9,   KC_F10,  KC_F11,
-        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, KC_GRV,  KC_MINS,  KC_LEFT, KC_DOWN,  KC_UP,   KC_RGHT, XXXXXXX, XXXXXXX,
+        KC_F12,  KC_F1,   KC_F2,   KC_F3,    KC_F4,   KC_F5,   XXXXXXX, XXXXXXX,  KC_F6,   KC_F7,    KC_F8,   KC_F9,   KC_F10,  KC_F11,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  KC_LEFT, KC_DOWN,  KC_UP,   KC_RGHT, XXXXXXX, XXXXXXX,
         _______, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX,          XXXXXXX,  XXXXXXX, XXXXXXX,  XXXXXXX, KC_MUTE, KC_VOLU, _______,
         _______, _______, _______,           _______,                             _______,           KC_MPLY, KC_MPRV, KC_VOLD, KC_MNXT
+    ),
+
+    /* Boot
+     */
+    [3] = LAYOUT(
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX,          XXXXXXX,  XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+        QK_BOOT, XXXXXXX, XXXXXXX,           XXXXXXX,                             XXXXXXX,           XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX
     )
 };

--- a/keyboards/oxwich50/keymaps/richdawe/keymap.c
+++ b/keyboards/oxwich50/keymaps/richdawe/keymap.c
@@ -1,0 +1,45 @@
+// Copyright 2024 Richard Dawe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+#define LT1_SPC LT(1, KC_SPC)
+#define LT2_ESC LT(2, KC_ESC)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Base layer
+     * ┌───┬───┬───┬───┐
+     * │ 7 │ 8 │ 9 │ / │
+     * ├───┼───┼───┼───┤
+     * │ 4 │ 5 │ 6 │ * │
+     * ├───┼───┼───┼───┤
+     * │ 1 │ 2 │ 3 │ - │
+     * ├───┼───┼───┼───┤
+     * │ 0 │ . │Ent│ + │
+     * └───┴───┴───┴───┘
+     */
+    [0] = LAYOUT(
+        KC_TAB,  KC_Q,    KC_W,    KC_E,     KC_R,    KC_T,    KC_LBRC, KC_RBRC,  KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_BSPC,
+        LT2_ESC, KC_A,    KC_S,    KC_D,     KC_F,    KC_G,    KC_GRV,  KC_MINS,  KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_B,     KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   KC_ENT,
+        KC_LCTL, KC_LGUI, KC_LALT,           LT1_SPC,                             LT1_SPC,           KC_SLSH, KC_LEFT, KC_DOWN, KC_RIGHT
+    ),
+
+    /* Numbers and symbols layer
+     */
+    [1] = LAYOUT(
+        KC_COLN, KC_1,    KC_2,    KC_3,     KC_4,    KC_5,    KC_LBRC, KC_RBRC,  KC_6,    KC_7,     KC_8,    KC_9,    KC_0,    KC_BSPC,
+        KC_DOT,  S(KC_1), S(KC_2), S(KC_3),  S(KC_4), S(KC_5), KC_GRV,  KC_MINS,  S(KC_6), S(KC_7),  S(KC_8), S(KC_9), S(KC_0), KC_BSLS,
+        _______, XXXXXXX, KC_GRV,  KC_TILD,  KC_PIPE, KC_PLUS,          KC_PLUS,  KC_MINS, KC_EQL,   KC_LBRC, KC_RBRC, KC_PGUP, _______,
+        _______, _______, _______,           _______,                             _______,           XXXXXXX, KC_HOME, KC_PGDN, KC_END
+    ),
+
+    /* F-keys and media
+     */
+    [2] = LAYOUT(
+        KC_F12,  KC_F1,   KC_F2,   KC_F3,    KC_F4,   KC_F5,   KC_LBRC, KC_RBRC,  KC_F6,   KC_F7,    KC_F8,   KC_F9,   KC_F10,  KC_F11,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX, KC_GRV,  KC_MINS,  KC_LEFT, KC_DOWN,  KC_UP,   KC_RGHT, XXXXXXX, XXXXXXX,
+        _______, XXXXXXX, XXXXXXX, XXXXXXX,  XXXXXXX, XXXXXXX,          XXXXXXX,  XXXXXXX, XXXXXXX,  XXXXXXX, KC_MUTE, KC_VOLU, _______,
+        _______, _______, _______,           _______,                             _______,           KC_MPLY, KC_MPRV, KC_VOLD, KC_MNXT
+    )
+};

--- a/keyboards/oxwich50/keymaps/richdawe/keymap.c
+++ b/keyboards/oxwich50/keymaps/richdawe/keymap.c
@@ -7,6 +7,8 @@
 #define LT2_ESC LT(2, KC_ESC)
 #define LT3_TAB LT(3, KC_TAB)
 
+#define MT_LASL LALT_T(KC_SLSH)
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Base layer
      * ┌───┬───┬───┬───┐
@@ -22,8 +24,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         LT3_TAB, KC_Q,    KC_W,    KC_E,     KC_R,    KC_T,    KC_LBRC, KC_RBRC,  KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_BSPC,
         LT2_ESC, KC_A,    KC_S,    KC_D,     KC_F,    KC_G,    KC_TILD, KC_MINS,  KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT,
-        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_SLSH,  KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   SC_SENT,
-        KC_LCTL, KC_LGUI, KC_LALT,           LT1_SPC,                             LT1_SPC,           KC_LALT, KC_LEFT, KC_DOWN, KC_RIGHT
+        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_B,     KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   SC_SENT,
+        KC_LCTL, KC_LGUI, KC_LALT,           LT1_SPC,                             LT1_SPC,           MT_LASL, KC_LEFT, KC_DOWN, KC_RIGHT
     ),
 
     /* Numbers and symbols layer

--- a/keyboards/oxwich50/keymaps/richdawe/keymap.c
+++ b/keyboards/oxwich50/keymaps/richdawe/keymap.c
@@ -22,7 +22,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         LT3_TAB, KC_Q,    KC_W,    KC_E,     KC_R,    KC_T,    KC_LBRC, KC_RBRC,  KC_Y,    KC_U,     KC_I,    KC_O,    KC_P,    KC_BSPC,
         LT2_ESC, KC_A,    KC_S,    KC_D,     KC_F,    KC_G,    KC_TILD, KC_MINS,  KC_H,    KC_J,     KC_K,    KC_L,    KC_SCLN, KC_QUOT,
-        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_SLSH,  KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   KC_ENT,
+        KC_LSFT, KC_Z,    KC_X,    KC_C,     KC_V,    KC_B,             KC_SLSH,  KC_N,    KC_M,     KC_COMM, KC_DOT,  KC_UP,   SC_SENT,
         KC_LCTL, KC_LGUI, KC_LALT,           LT1_SPC,                             LT1_SPC,           KC_LALT, KC_LEFT, KC_DOWN, KC_RIGHT
     ),
 

--- a/keyboards/oxwich50/readme.md
+++ b/keyboards/oxwich50/readme.md
@@ -1,0 +1,27 @@
+# oxwich50
+
+![oxwich50](imgur.com image replace me!)
+
+*A short description of the keyboard/project*
+
+* Keyboard Maintainer: [Elliot Powell](https://github.com/Elliot Powell)
+* Hardware Supported: *The PCBs, controllers supported*
+* Hardware Availability: *Links to where you can find this hardware*
+
+Make example for this keyboard (after setting up your build environment):
+
+    make oxwich50:default
+
+Flashing example for this keyboard:
+
+    make oxwich50:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/oxwich50/rules.mk
+++ b/keyboards/oxwich50/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
Add the source code for the Oxwich50 keyboard, designed by Mechboards UK for me.

Add my initial keymap.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
